### PR TITLE
build: fix typo in pyproject.toml and update test suite

### DIFF
--- a/alpenhorn_chime/detection.py
+++ b/alpenhorn_chime/detection.py
@@ -4,6 +4,7 @@ CHIME's import detection logic is fairly simple and
 is performed by pattern matching on the acqusition
 directory and filename.
 """
+
 from __future__ import annotations
 from typing import TYPE_CHECKING
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["setuptools>=61.0.0.", "wheel", "setuptools-git-versioning"]
-build-backed = "setuptools.build_meta"
+requires = ["setuptools>=61.0.0", "wheel", "setuptools-git-versioning"]
+build-backend = "setuptools.build_meta"
 
 [project]
 name = "alpenhorn_chime"

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -4,7 +4,7 @@ import pytest
 import chimedb.core as db
 from alpenhorn import db as adb
 from alpenhorn.archive import ArchiveFileCopy, ArchiveFileCopyRequest
-from alpenhorn.storage import StorageNode, StorageGroup
+from alpenhorn.storage import StorageNode, StorageGroup, StorageTransferAction
 
 from chimedb.data_index.orm import (
     AcqFileTypes,
@@ -66,6 +66,7 @@ def tables(proxy):
             RawadcFileInfo,
             StorageGroup,
             StorageNode,
+            StorageTransferAction,
             WeatherFileInfo,
         ]
     )

--- a/test/test_import.py
+++ b/test/test_import.py
@@ -1,4 +1,5 @@
 """Test everything by running alpenhorn import on the test data."""
+
 import pytest
 
 import shutil


### PR DESCRIPTION
This is the source of the typo in https://github.com/chime-experiment/chimedb_di/pull/26

I was trying to just fix a single typo, but here we are now.  I've also fixed the test suite for changes made in alpenhorn.

Also, reblackened.