### PR TITLE
feat(info): Add support for chime_timing files

### DIFF
--- a/alpenhorn_chime/info.py
+++ b/alpenhorn_chime/info.py
@@ -12,6 +12,7 @@ from chimedb.data_index.orm import (
     HFBFileInfo,
     RawadcAcqInfo,
     RawadcFileInfo,
+    TimingCorrectionFileInfo,
     WeatherFileInfo,
 )
 
@@ -38,4 +39,6 @@ def cal_info_class(file: ArchiveFile) -> type[CalibrationFileInfo]:
         return CalibrationGainFileInfo
     if acqtype_name == "flaginput":
         return FlagInputFileInfo
+    if acqtype_name == "timing":
+        return TimingCorrectionFileInfo
     raise ValueError(f'unknown acqtype: {acqtype_name}"')


### PR DESCRIPTION
Add chime-timing support.  Requires https://github.com/chime-experiment/chimedb_di/pull/30

This is just providing some glue between alpenhorn and our database models over in `chimedb.data_index`.