### PR TITLE
feat: Update for Alpenhorn Extension API

### DIFF
--- a/alpenhorn_chime/__init__.py
+++ b/alpenhorn_chime/__init__.py
@@ -1,11 +1,22 @@
 """Alpenhorn extensions for CHIME."""
 
-from .detection import import_detect
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("alpenhorn_chime")
+except PackageNotFoundError:
+    # package is not installed
+    pass
+del version, PackageNotFoundError
 
 
-def register_extension() -> dict:
-    """Return alpenhorn extension data.
+def register_extensions() -> dict:
+    """Provide the extension to alpenhorn.
 
     This module provides the CHIME import-detect routine.
     """
-    return {"import-detect": import_detect}
+    global __version__
+    from alpenhorn.extensions import ImportDetectExtension
+    from .detection import import_detect
+
+    return [ImportDetectExtension("Detect", __version__, detect=import_detect)]

--- a/alpenhorn_chime/detection.py
+++ b/alpenhorn_chime/detection.py
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
     from alpenhorn.db import ArchiveFileCopy
-    from alpenhorn.daemon.update import UpdateableNode
+    from alpenhorn.daemon import UpdateableNode
 del TYPE_CHECKING
 
 log = logging.getLogger("alpenhorn_chime")

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -7,8 +7,11 @@ from alpenhorn.db import (
     ArchiveFileCopy,
     ArchiveFileCopyRequest,
     ArchiveFileImportRequest,
+    DataIndexVersion,
+    StorageNode,
+    StorageGroup,
+    StorageTransferAction,
 )
-from alpenhorn.db import StorageNode, StorageGroup, StorageTransferAction
 
 from chimedb.data_index.orm import (
     AcqFileTypes,
@@ -62,6 +65,7 @@ def tables(proxy):
             CalibrationGainFileInfo,
             CorrAcqInfo,
             CorrFileInfo,
+            DataIndexVersion,
             DigitalGainFileInfo,
             FileType,
             FlagInputFileInfo,

--- a/test/test_import.py
+++ b/test/test_import.py
@@ -12,7 +12,13 @@ from unittest.mock import patch
 
 from chimedb.data_index import util
 
-from alpenhorn.db import ArchiveFileCopy, StorageGroup, StorageNode
+from alpenhorn.db import (
+    ArchiveFileCopy,
+    DataIndexVersion,
+    StorageGroup,
+    StorageNode,
+    current_version,
+)
 
 from chimedb.data_index.orm import (
     CorrAcqInfo,
@@ -53,6 +59,9 @@ def tempdb():
 @pytest.fixture
 def chime_data(tables):
     """Ensure the CHIME data has been added to the database."""
+
+    # Set schema version
+    DataIndexVersion.create(component="alpenhorn", version=current_version)
 
     util.update_types()
     util.update_inst()


### PR DESCRIPTION
* Calculate `__version__` in `__init__` in the standard way.
* Update the `register_extensions` function in `__init__` to return a new-fangled `alpenhorn.extensions.ImportDetectExtension`
* Set the alpenhorn schema version in the test suite to permit alpenhorn start-up.  (It would be nice if we could just initialise the alpenhorn data index via `alpenhorn db init`, but that won't work because we need a different `ArchiveAcq` and `ArchiveFile` tables than what `alpenhorn` wants to create.)